### PR TITLE
superfluous dot breaks plugin functionality

### DIFF
--- a/tpl/showConfigSingleLine.php
+++ b/tpl/showConfigSingleLine.php
@@ -61,7 +61,7 @@
 	                    </div>
 					</td>
 					<td>
-						<img src="<?php echo .DOKU_PLUGIN_ICONS.'delete_disabled.png' ?>"
+						<img src="<?php echo DOKU_PLUGIN_ICONS.'delete_disabled.png' ?>"
 	                        alt="<?php echo hsc($helper->getLang('delete_action')) ?>"
 	                        title="<?php echo hsc($helper->getLang('delete_action_tooltip_disabled')) ?>" />
 	                </td>


### PR DESCRIPTION
it was introduced by me in d39eed4.
i first thought it's small mistake. plan to request for pull on next big update.

but i just found that dot will break the plugin functionality, 
so, please pull it soon.
