### PR TITLE
Fix undefined method call to actuallySaveFile()

### DIFF
--- a/configTypes/ConfigManagerSingleLineConfigCascade.php
+++ b/configTypes/ConfigManagerSingleLineConfigCascade.php
@@ -97,7 +97,7 @@ class ConfigManagerSingleLineCoreConfig extends ConfigManagerAbstractCascadeConf
             $content .= "$item\n";
         }
 
-        $this->helper->actuallySaveFile($file, $content);
+        $this->helper->saveFile($file, $content);
     }
 
 

--- a/configTypes/ConfigManagerTwoLine.php
+++ b/configTypes/ConfigManagerTwoLine.php
@@ -108,6 +108,6 @@ class ConfigManagerTwoLine implements ConfigManagerConfigType {
             $content .= "$key\t$value\n";
         }
 
-        $this->helper->actuallySaveFile($this->configFile, $content);
+        $this->helper->saveFile($this->configFile, $content);
     }
 }

--- a/configTypes/ConfigManagerTwoLineConfigCascade.php
+++ b/configTypes/ConfigManagerTwoLineConfigCascade.php
@@ -107,7 +107,7 @@ class ConfigManagerTwoLineCascadeConfig extends ConfigManagerAbstractCascadeConf
             $content .= "$key\t$value\n";
         }
 
-        $this->helper->actuallySaveFile($file, $content);
+        $this->helper->saveFile($file, $content);
     }
 
     /**


### PR DESCRIPTION
With change sha1:d96ae4c8e11c8c083d831c32696abfd0cdc45fe1 the helper
method actuallySaveFile() was renamed to saveFile().

Error was:

PHP Fatal error:
Call to undefined method helper_plugin_confmanager::actuallySaveFile()
in
../lib/plugins/confmanager/configTypes/ConfigManagerTwoLineConfigCascade.php
on line 110

Signed-off-by: Stephan Linz <linz@li-pro.net>