### PR TITLE
remove unused strings from all languages

### DIFF
--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -8,8 +8,6 @@
  * @author ParoTheParrot <parotheparrot@gmail.com>
  * @author Dana <dannax3@gmx.de>
  */
-$lang['encoding']              = 'utf-8';
-$lang['direction']             = 'ltr';
 $lang['menu']                  = 'Konfigurationsdateimanager';
 $lang['welcomehead']           = 'Konfigurationsdateimanager';
 $lang['welcome']               = 'Der Konfigurationsdateimanager lässt dich verschiedene Konfigurationen an DokuWiki und DokuWiki Plugins vornehmen.';
@@ -17,13 +15,8 @@ $lang['save']                  = 'Speichern';
 $lang['select_config']         = 'Wähle eine Konfigurationsdatei';
 $lang['please_select']         = '--- Bitte wähle einen Eintrag aus ---';
 $lang['edit']                  = 'Editieren';
-$lang['cannot change default file icon'] = 'Standardicons können nicht geändert werden';
 $lang['delete_action']         = 'löschen';
-$lang['edit_key_action']       = 'editieren';
-$lang['edit_key_action_tooltip'] = 'Zum Umbenennen hier klicken';
 $lang['delete_action_tooltip'] = 'Zum Löschen hier klicken';
-$lang['delete_action_tooltip_disabled'] = 'Standardwerte können nicht gelöscht werden';
-$lang['edit_key_action_tooltip_disabled'] = 'Standardwerte können nicht editiert werden.';
 $lang['default_value_tooltip'] = 'Dies ist ein Standardwert und kann nicht verändert werden';
 $lang['edit_icon_action']      = 'Editiere das Icon';
 $lang['edit_icon_action_disabled'] = 'Icon kann nicht editiert werden';
@@ -32,8 +25,6 @@ $lang['edit_icon_action_tooltip_disabled'] = 'Standardicons können nicht verän
 $lang['toggle_description']    = 'Schalte Beschreibungen an/aus';
 $lang['toggle_defaults']       = 'Zeige/verstecke Standardwerte';
 $lang['defaults_description']  = 'Bitte beachte: Standardwerte legen das grundlegende verhalten von DokuWiki fest und können nicht geändert werden.';
-$lang['add_action']            = 'Hinzufügen';
-$lang['add_action_tooltip']    = 'Klicke hier um ein neues Element hinzuzufügen';
 $lang['no_script_title']       = 'Du hast dein JavaScript deaktiviert!';
 $lang['no_script_message']     = 'Nur mit JavaScript kannst du alle Funktionen des Konfigurationsdateimanagers verwenden.';
 $lang['file_upload_prompt']    = 'Bitte wähle ein Icon aus';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -5,8 +5,6 @@
  *
  * @author Schplurtz le Déboulonné <schplurtz@laposte.net>
  */
-//$lang['encoding']              = 'utf-8';
-//$lang['direction']             = 'ltr';
 $lang['menu']                  = 'Configuration File Manager';
 $lang['welcomehead']           = 'Configuration File Manager';
 $lang['welcome']               = 'The Configuration File Manager allows you to edit various configuration files from DokuWiki and its plug-ins.';
@@ -14,13 +12,8 @@ $lang['save']                  = 'Save';
 $lang['select_config']         = 'Select a configuration file';
 $lang['please_select']         = '--- Please select an entry ---';
 $lang['edit']                  = 'Edit';
-//$lang['cannot change default file icon'] = 'Cannot change default icons';
 $lang['delete_action']         = 'delete';
 $lang['delete_action_tooltip'] = 'Click here to delete this entry';
-//$lang['delete_action_tooltip_disabled'] = 'Cannot delete default values';
-//$lang['edit_key_action']       = 'edit';
-//$lang['edit_key_action_tooltip'] = 'Click here to rename this entry';
-//$lang['edit_key_action_tooltip_disabled'] = 'Cannot edit default values';
 $lang['disable_action']        = 'disable';
 $lang['disable_action_tooltip'] = 'Click here to disable this entry';
 $lang['disable_action_tooltip_disabled'] = 'The default value is already disabled by a user defined value.';
@@ -36,8 +29,6 @@ $lang['modifiesdefault']       = 'Overrides a default value.';
 $lang['toggle_description']    = 'Toggle description on/off';
 $lang['toggle_defaults']       = 'Toggle display of default values on/off';
 $lang['defaults_description']  = 'Please note: default values define the basic behavior of DokuWiki and cannot be changed.';
-//$lang['add_action']            = 'add';
-//$lang['add_action_tooltip']    = 'Click here to add the new item to the list';
 $lang['no_script_title']       = 'JavaScript is disabled!';
 $lang['no_script_message']     = 'As long as JavaScript is disabled, confmanager offers only basic functionality. To benefit from convenience functions like collapsing sections, quick actions on items, etc. turn on your JavaScript. We won\'t hurt you. Promise.';
 $lang['file_upload_prompt']    = 'Please select an image file to upload';

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -6,8 +6,6 @@
  * @author Schplurtz le Déboulonné <schplurtz@laposte.net>
  * @author Nicolas Friedli <nicolas@theologique.ch>
  */
-$lang['encoding']              = 'utf-8';
-$lang['direction']             = 'ltr';
 $lang['menu']                  = 'Gestionnaire de fichiers de configuration';
 $lang['welcomehead']           = 'Gestionnaire de fichiers de configuration';
 $lang['welcome']               = 'Le gestionnaire de fichiers de configuration permet d\'éditer divers fichiers de configuration de DokuWiki et de ses extensions.';
@@ -15,13 +13,8 @@ $lang['save']                  = 'Enregistrer';
 $lang['select_config']         = 'Sélection d\'un fichier de configuration';
 $lang['please_select']         = '--- Veuillez choisir ---';
 $lang['edit']                  = 'Modifier';
-$lang['cannot change default file icon'] = 'Impossible de changer les icônes par défaut.';
 $lang['delete_action']         = 'Supprimer';
-$lang['edit_key_action']       = 'modifier';
-$lang['edit_key_action_tooltip'] = 'Cliquez ici pour renommer';
 $lang['delete_action_tooltip'] = 'Cliquer ici pour supprimer.';
-$lang['delete_action_tooltip_disabled'] = 'Impossible de supprimer les valeurs par défaut.';
-$lang['edit_key_action_tooltip_disabled'] = 'Impossible de modifier les valeurs par défaut.';
 $lang['default_value_tooltip'] = 'Valeur par défaut qu\'on ne peut pas modifier.';
 $lang['edit_icon_action']      = 'Modifier l\'icône';
 $lang['edit_icon_action_disabled'] = 'Impossible de modifier l\'icône.';
@@ -30,8 +23,6 @@ $lang['edit_icon_action_tooltip_disabled'] = 'Impossible de changer les icônes 
 $lang['toggle_description']    = '(dé)activer les descriptions.';
 $lang['toggle_defaults']       = '(dé)activer l\'affichage des valeurs par défaut.';
 $lang['defaults_description']  = 'Les valeurs par défaut définissent le comportement de base de DokuWiki et ne peuvent être changées.';
-$lang['add_action']            = 'ajouter';
-$lang['add_action_tooltip']    = 'Cliquer pour ajouter un nouvel article à la liste.';
 $lang['no_script_title']       = 'JavaScript est désactivé.';
 $lang['no_script_message']     = 'Tant que JavaScript est désactivé, le gestionnaire de configuration n\'offre que des fonctionnalités de base. Pour bénéficier des fonctions d\'agrément, comme le repli de sections, les actions rapides, etc… veuillez activer JavaScript. On ne vous fera pas mal, promis.';
 $lang['file_upload_prompt']    = 'Veuillez choisir une image à téléverser.';

--- a/lang/ja/lang.php
+++ b/lang/ja/lang.php
@@ -5,8 +5,6 @@
  *
  * @author Hideaki SAWADA <chuno@live.jp>
  */
-$lang['encoding']              = 'utf-8';
-$lang['direction']             = 'ltr';
 $lang['menu']                  = '設定ファイル管理';
 $lang['welcomehead']           = '設定ファイル管理';
 $lang['welcome']               = '設定ファイル管理では、DokuWiki とプラグイン用のいくつかの設定ファイルを編集することができます。';
@@ -14,13 +12,8 @@ $lang['save']                  = '保存';
 $lang['select_config']         = '設定ファイルの選択';
 $lang['please_select']         = '--- 選択して下さい ---';
 $lang['edit']                  = '編集';
-$lang['cannot change default file icon'] = 'デフォルトアイコンは変更不可';
 $lang['delete_action']         = '削除';
-$lang['edit_key_action']       = '編集';
-$lang['edit_key_action_tooltip'] = 'この項目名を変更するにはここをクリック';
 $lang['delete_action_tooltip'] = 'この項目を削除するにはここをクリック';
-$lang['delete_action_tooltip_disabled'] = 'デフォルト値の削除不可';
-$lang['edit_key_action_tooltip_disabled'] = 'デフォルト値の編集不可';
 $lang['default_value_tooltip'] = 'これは変更不可なデフォルト値です';
 $lang['edit_icon_action']      = 'アイコンの編集';
 $lang['edit_icon_action_disabled'] = 'アイコンの編集不可';
@@ -29,8 +22,6 @@ $lang['edit_icon_action_tooltip_disabled'] = 'デフォルトアイコンの変�
 $lang['toggle_description']    = '説明の表示／非表示';
 $lang['toggle_defaults']       = 'デフォルト値の表示／非表示';
 $lang['defaults_description']  = '注意：デフォルト値は、DokuWikiの基本的な動作を定義しており、変更することはできません。';
-$lang['add_action']            = '追加';
-$lang['add_action_tooltip']    = '一覧への新規項目の追加にはここをクリック';
 $lang['no_script_title']       = 'JavaScriptが無効です！';
 $lang['no_script_message']     = 'JavaScriptが無効な間、設定ファイル管理は基本的な機能しか提供しません。節の折りたたみ・項目の迅速な操作といった便利な機能を使用するには、JavaScriptを有効にして下さい。';
 $lang['file_upload_prompt']    = 'アップロードする画像ファイルを選択して下さい。';

--- a/lang/ko/lang.php
+++ b/lang/ko/lang.php
@@ -5,8 +5,6 @@
  * 
  * @author relue2718 <webmaster@relue2718.com>
  */
-$lang['encoding']              = 'utf-8';
-$lang['direction']             = 'itr';
 $lang['menu']                  = '설정 파일 관리자';
 $lang['welcomehead']           = '설정 파일 관리자';
 $lang['welcome']               = '설정 파일 관리자는 DokuWiki와 plug-in들의 다양한 설정 파일을 관리할 수 있도록 도와줍니다.';
@@ -14,13 +12,8 @@ $lang['save']                  = '저장하기';
 $lang['select_config']         = '설정 파일 선택';
 $lang['please_select']         = '--- 항목을 선택하세요 ---';
 $lang['edit']                  = '편지';
-$lang['cannot change default file icon'] = '기본 아이콘은 변경할 수 없습니다';
 $lang['delete_action']         = '삭제';
-$lang['edit_key_action']       = '편집';
-$lang['edit_key_action_tooltip'] = '이 항목의 이름을 바꾸려면 여기를 클릭하세요';
 $lang['delete_action_tooltip'] = '이 항목을 지우려면 여기를 클릭하세요';
-$lang['delete_action_tooltip_disabled'] = '기본값은 지울 수 없습니다';
-$lang['edit_key_action_tooltip_disabled'] = '기본값은 바꿀 수 없습니다';
 $lang['default_value_tooltip'] = '변경이 허용되지 않는 기본값입니다.';
 $lang['edit_icon_action']      = '아이콘 편집';
 $lang['edit_icon_action_disabled'] = '아이콘 편집할 수 없음';
@@ -29,8 +22,6 @@ $lang['edit_icon_action_tooltip_disabled'] = '기본 아이콘을 변경할 수 
 $lang['toggle_description']    = '설명 켜기/끄기';
 $lang['toggle_defaults']       = '기본값 표시 켜기/끄기';
 $lang['defaults_description']  = '기본값은 DokuWiki의 기본적인 동작을 정의하고 변경될 수 없습니다.';
-$lang['add_action']            = '추가';
-$lang['add_action_tooltip']    = '새로운 항목 추가하기';
 $lang['no_script_title']       = '자바스크립트가 비활성화 되어 있습니다!';
 $lang['no_script_message']     = '자바스크립트가 비활성화 되었기 때문에 confmanager는 일부 기능만을 제공합니다. 섹션을 접거나 아이템의 빠른 동작을 실행하기 위해서는 자바스크립트를 켜야 합니다. 컴퓨터를 망치지 않아요. 약속합니다.';
 $lang['file_upload_prompt']    = '업로드할 이미지 파일을 선택하세요';

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -6,8 +6,6 @@
  * @author Gerrit Uitslag <klapinklapin@gmail.com>
  * @author Mark C. Prins <mprins@users.sf.net>
  */
-$lang['encoding']              = 'utf-8';
-$lang['direction']             = 'ltr';
 $lang['menu']                  = 'Configuratiebestandenbeheerder';
 $lang['welcomehead']           = 'Configuratiebestandenbeheerder';
 $lang['welcome']               = 'De configuratiebestandenbeheerder laat je verschillende configuratie bestanden van DokuWiki en zijn plugins aanpassen.';
@@ -15,13 +13,8 @@ $lang['save']                  = 'Opslaan';
 $lang['select_config']         = 'Selecteer een configuratiebestand';
 $lang['please_select']         = '-- Selecteer alsjeblieft een bestand --';
 $lang['edit']                  = 'Bewerken';
-$lang['cannot change default file icon'] = 'Standaard iconen kunnen niet gewijzigd worden';
 $lang['delete_action']         = 'verwijderen';
-$lang['edit_key_action']       = 'bewerken';
-$lang['edit_key_action_tooltip'] = 'Klik hier om de regel te hernoemen';
 $lang['delete_action_tooltip'] = 'Klik hier om de regel te verwijderen';
-$lang['delete_action_tooltip_disabled'] = 'Standaardwaardes kunnen niet verwijderd worden';
-$lang['edit_key_action_tooltip_disabled'] = 'Standaardwaardes kunnen niet gewijzigd worden';
 $lang['default_value_tooltip'] = 'Dit is een standaardwaarde die niet gewijzigd kan worden';
 $lang['edit_icon_action']      = 'icoon aanpassen';
 $lang['edit_icon_action_disabled'] = 'kan icoon niet aanpassen';
@@ -30,8 +23,6 @@ $lang['edit_icon_action_tooltip_disabled'] = 'Standaard icoon kan niet gewijzigd
 $lang['toggle_description']    = 'Beschrijving weergeven/verbergen';
 $lang['toggle_defaults']       = 'Standaardwaardes weergeven/verbergen';
 $lang['defaults_description']  = 'Merk op: standaardwaardes definiëren het standaardgedrag van DokuWiki en kunnen hier niet aangepast worden.';
-$lang['add_action']            = 'toevoegen';
-$lang['add_action_tooltip']    = 'Klik hier om een nieuw item aan de lijst toe te voegen';
 $lang['no_script_title']       = 'JavaScript is uitgeschakeld!';
 $lang['no_script_message']     = 'Zolang Javascript is uitgeschakeld biedt ConfManager alleen basisfunctionaliteit. Om te profiteren van meer gemak zoals in/uitklappende alinea\'s, snelle acties op items, etc. zet je Javascript aan.';
 $lang['file_upload_prompt']    = 'Selecteer alsjeblieft een afbeeldingsbestand om te uploaden';

--- a/lang/zh/lang.php
+++ b/lang/zh/lang.php
@@ -3,8 +3,6 @@
 
 // These settings must be present and set appropriately for the language.
 // Do not change, if you don't know what it does!
-$lang['encoding']   = 'utf-8';
-$lang['direction']  = 'ltr';
 
 
 // For admin plugins, the menu prompt to be displayed in the admin menu.
@@ -22,13 +20,8 @@ $lang['save'] = '保存';
 $lang['select_config'] = '选择一个配置文件';
 $lang['please_select'] = '--- 请选择一个条目 ---';
 $lang['edit'] = '编辑';
-$lang['cannot change default file icon'] = '不能改变默认图标';
 $lang['delete_action'] = '删除';
-$lang['edit_key_action'] = '编辑';
-$lang['edit_key_action_tooltip'] = '点击重命名这一条目';
 $lang['delete_action_tooltip'] = '点击删除这一条目';
-$lang['delete_action_tooltip_disabled'] = '不能删除默认值';
-$lang['edit_key_action_tooltip_disabled'] = '不能编辑默认值';
 $lang['default_value_tooltip'] = '这是一个默认值，不能被改变';
 $lang['edit_icon_action'] = '编辑图标';
 $lang['edit_icon_action_disabled'] = '不能编辑图标';
@@ -37,8 +30,6 @@ $lang['edit_icon_action_tooltip_disabled'] = '不能改变默认图标';
 $lang['toggle_description'] = '切换显示和隐藏描述';
 $lang['toggle_defaults'] = '切换显示和隐藏默认值';
 $lang['defaults_description'] = '请注意：默认值定义了 Dokuwiki 的基础行为，不能被改变。';
-$lang['add_action'] = '添加';
-$lang['add_action_tooltip'] = '点击添加新的条目到这个列表';
 $lang['no_script_title'] = 'JavaScript 被禁用了！';
 $lang['no_script_message'] = '由于 JavaScript 被禁用了，confmanager 只提供一些基础功能。为了方便地使用像折叠，条目上的快捷操作等等。请打开你的 JavaScript 支持。我们保证不会伤害你的，亲。';
 $lang['file_upload_prompt'] = '请选择要上传的图片文件';


### PR DESCRIPTION
Hi,

I just noticed that this plugin is translated at 102% on [translate.dokuwiki.org ](https://translate.dokuwiki.org/plugin/confmanager);-). => There are non English strings that still linger.

This PR removes them all from all languages and removes the commented out strings from the English version.